### PR TITLE
ci: Add conda build and use micromamba

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -1,0 +1,27 @@
+name: conda
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          micromamba-version: '2.0.2-0'
+          environment-file: logic1_dev.yaml
+          init-shell: bash
+          cache-environment: true
+          post-cleanup: 'all'
+          generate-run-shell: true
+
+      - name: Build conda package
+        run: make conda-build
+        shell: micromamba-shell {0}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,17 +9,24 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          sudo apt-get -y install graphviz
-      - run: |
-          source $CONDA/etc/profile.d/conda.sh
-          CFLAGS="-Wno-incompatible-pointer-types" conda env create -f logic1_dev.yaml
-          conda activate logic1_dev
-          conda env list
-          conda list
-          export PYTHONPATH="$PYTHONPATH:$(pwd)"
-          cd doc
-          make html
+
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          micromamba-version: '2.0.2-0'
+          environment-file: logic1_dev.yaml
+          init-shell: bash
+          cache-environment: true
+          post-cleanup: all
+          generate-run-shell: true
+
+      - name: Install Graphviz
+        run: sudo apt-get -y install graphviz
+
+      - name: Generate Documentation in HTML format
+        run: PYTHONPATH="$PYTHONPATH:$(pwd)" make html
+        shell: micromamba-shell {0}
+        working-directory: doc
+
       - uses: actions/upload-pages-artifact@v3
         with: { path: 'doc/build/html' }
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - uses: mamba-org/setup-micromamba@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist
 
 # PyCharm
 .idea
+
+# rattler-build
+output

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: pytest pytest-full test-doc mypy test test-all doc pygount\
-		coverage coverage_html clean veryclean
+		coverage coverage_html clean veryclean conda-build
 
 pytest:
 	pytest -n 8 --exitfirst --doctest-modules
@@ -38,3 +38,10 @@ clean:
 
 veryclean:
 	rm -rf htmlcov .coverage
+
+conda-build:
+	LOGIC1_GIT_REPO="file:$$(pwd)" \
+	LOGIC1_GIT_REV="$$(git rev-parse HEAD)" \
+	LOGIC1_VERSION="$$(python -m setuptools_scm)" \
+	rattler-build build --recipe conda
+

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -1,0 +1,39 @@
+source:
+  git: ${{ env.get("LOGIC1_GIT_REPO") }}
+  rev: ${{ env.get("LOGIC1_GIT_REV") }}
+
+package:
+  name: logic1
+  version: ${{ env.get("LOGIC1_VERSION") }}
+
+build:
+  number: 0
+  noarch: python
+  script: python -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.11,<3.12
+    - pip
+    - setuptools_scm
+  run:
+    - more-itertools
+    - pyeda
+    - sage
+    - typing-extensions
+
+tests:
+  - python:
+      imports:
+        - logic1
+      pip_check: false
+  - script:
+      - python -m doctest -o NORMALIZE_WHITESPACE logic1/theories/Sets/test_qe.txt
+    files:
+      source:
+        - logic1/theories/Sets/test_qe.txt
+
+about:
+  license: GPL-2.0-or-later
+  summary: Interpreted first-order logic in Python
+  homepage: https://docs.logic1.eu/

--- a/logic1_dev.yaml
+++ b/logic1_dev.yaml
@@ -24,6 +24,7 @@ dependencies:
   - pytest
   - pytest-xdist
   - sage
+  - setuptools_scm
   - snakeviz
   - sphinx
   - sphinx-book-theme

--- a/logic1_dev.yaml
+++ b/logic1_dev.yaml
@@ -23,6 +23,7 @@ dependencies:
   - pyeda
   - pytest
   - pytest-xdist
+  - rattler-build
   - sage
   - setuptools_scm
   - snakeviz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "logic1"
-version = "0.1.0"
+dynamic = ["version"] # See https://setuptools-scm.readthedocs.io/en/v8.1.0/usage/
 description = "Interpreted first-order logic in Python"
 authors = [
   {name = "Nicolas Faroß", email = "faross@math.uni-sb.de"},
@@ -14,8 +14,6 @@ readme = "README.md"
 dependencies = [
   "more-itertools",
   "pyeda",
-  "sphinx",
-  "sphinx-book-theme",
 ]
 requires-python = ">=3.11,<3.12"
 classifiers = [
@@ -26,3 +24,12 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Typing :: Typed"
 ]
+
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["logic1*"]
+
+[tool.setuptools_scm]


### PR DESCRIPTION
With this change, we'll be able to build a conda-compatible redistributable package for Logic1. It adds a new target to `./Makefile`, so that the package can be built locally with

    make conda-build

and a workflow for GitHub Actions called "[conda](https://github.com/logic1-eu/logic1/actions/workflows/conda.yaml)".

Version generation of the project is tied to the Git history, via [`setuptools-scm`](https://setuptools-scm.readthedocs.io/). This way, the version does not have to be "written down" explicitly in any file (neither `pyproject.toml` nor `conda/recipe.yaml`). Use `git tag` to create a new version.