### PR TITLE
conda: Bump requirement for Python

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -13,7 +13,7 @@ build:
 
 requirements:
   host:
-    - python >=3.11,<3.12
+    - python >=3.12,<3.13
     - pip
     - setuptools_scm
   run:


### PR DESCRIPTION
In `c42d0a8014184a692ab9bb6fcb1155d32b01ab36`, development was updated to target Python 3.12 and in `a6236af689b24eb4068ab385ff4176b9db39ab12` the Conda environment for running with Python 3.11 was removed.

Also update the Conda recipe that is used in the "conda" GitHub Action.